### PR TITLE
Use hash routing for OAuth callback

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -411,7 +411,7 @@ def google_callback(request: Request):
                 logger.error(f"[{cid}] FRONTEND_ORIGIN não configurado")
                 raise HTTPException(status_code=500, detail="FRONTEND_ORIGIN não configurado")
             return RedirectResponse(
-                url=f"{frontend_origin}/oauth-ok?token={token}",
+                url=f"{frontend_origin}/#/oauth-ok?token={token}",
                 status_code=302,
             )
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,7 +5,7 @@ import './styles/global.css';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { GoogleOAuthProvider } from '@react-oauth/google';
 import { loadThemeFromStorage } from './utils/theme';
 import './index.css';
@@ -21,11 +21,11 @@ if (!rootElement) {
   ReactDOM.createRoot(rootElement).render(
     <React.StrictMode>
       <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID as string}>
-        <BrowserRouter basename={import.meta.env.BASE_URL}>
+        <HashRouter basename={import.meta.env.BASE_URL}>
           <ErrorBoundary>
             <App />
           </ErrorBoundary>
-        </BrowserRouter>
+        </HashRouter>
       </GoogleOAuthProvider>
     </React.StrictMode>,
   );


### PR DESCRIPTION
## Summary
- Switch frontend to HashRouter to avoid 404 on OAuth callback
- Redirect backend Google login callback to hash-based route

## Testing
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89c575f848322a9105128fa7c0fc8