### PR TITLE
feat(frontend): add private route guard

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,7 +8,7 @@ import Home from './pages/Home/Home'
 import OAuthOk from './pages/OAuthOk'
 
 import PoliticaDeCookies from './pages/PoliticaDeCookies'
-import RouteGuard from './routes/RouteGuard'
+import PrivateRoute from './router/PrivateRoute'
 import routesConfig from './routes/routesConfig'
 
 
@@ -28,18 +28,18 @@ const App: React.FC = () => {
 
 
       {/* Página principal Home */}
-      <Route path="/home" element={<RouteGuard><Home /></RouteGuard>} />
+      <Route path="/home" element={<PrivateRoute><Home /></PrivateRoute>} />
 
       {/* Rotas de cadastro; montam a Home para exibir conteúdo interno */}
-      <Route path="/cadastro/*" element={<RouteGuard><Home /></RouteGuard>} />
+      <Route path="/cadastro/*" element={<PrivateRoute><Home /></PrivateRoute>} />
 
       {/* Rotas de configuração definidas no arquivo de rotas */}
       {routesConfig.map((r) => (
-        <Route key={r.path} path={r.path} element={<RouteGuard><Home /></RouteGuard>} />
+        <Route key={r.path} path={r.path} element={<PrivateRoute><Home /></PrivateRoute>} />
       ))}
 
       {/* Página de acesso negado */}
-      <Route path="/403" element={<RouteGuard><Home /></RouteGuard>} />
+      <Route path="/403" element={<PrivateRoute><Home /></PrivateRoute>} />
 
       {/* Fallback opcional para rotas desconhecidas */}
       <Route path="*" element={<Navigate to="/login" replace />} />

--- a/frontend/src/pages/Home/Home.test.tsx
+++ b/frontend/src/pages/Home/Home.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import { render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Home from './Home'
-import RouteGuard from '@/routes/RouteGuard'
+import PrivateRoute from '@/router/PrivateRoute'
 
 function mockPerfil(perfil: string, perms?: Record<string, Record<string, boolean>>) {
   const effective =
@@ -62,8 +62,8 @@ test('rota de feriados bloqueada para professor', async () => {
   render(
     <MemoryRouter initialEntries={['/cadastro/feriados']}>
       <Routes>
-        <Route path='/cadastro/*' element={<RouteGuard><Home /></RouteGuard>} />
-        <Route path='/403' element={<RouteGuard><Home /></RouteGuard>} />
+        <Route path='/cadastro/*' element={<PrivateRoute><Home /></PrivateRoute>} />
+        <Route path='/403' element={<PrivateRoute><Home /></PrivateRoute>} />
       </Routes>
     </MemoryRouter>
   )
@@ -77,8 +77,8 @@ test('rota de ano letivo bloqueada para professor', async () => {
   render(
     <MemoryRouter initialEntries={['/cadastro/ano-letivo']}>
       <Routes>
-        <Route path='/cadastro/*' element={<RouteGuard><Home /></RouteGuard>} />
-        <Route path='/403' element={<RouteGuard><Home /></RouteGuard>} />
+        <Route path='/cadastro/*' element={<PrivateRoute><Home /></PrivateRoute>} />
+        <Route path='/403' element={<PrivateRoute><Home /></PrivateRoute>} />
       </Routes>
     </MemoryRouter>
   )

--- a/frontend/src/router/PrivateRoute.tsx
+++ b/frontend/src/router/PrivateRoute.tsx
@@ -1,0 +1,42 @@
+import { useEffect } from 'react'
+import { Navigate } from 'react-router-dom'
+import { apiFetch, getAuthToken, clearAuthToken } from '@/services/api'
+import useBaseNavigate from '@/hooks/useBaseNavigate'
+
+interface Props {
+  children: React.ReactElement
+}
+
+/**
+ * Protege rotas verificando existência e validade do token.
+ * - Sem token: redireciona para login sem chamar /me
+ * - Com token: renderiza children e valida /me de forma lazy
+ * - 401 no /me: limpa storage e redireciona para login
+ */
+const PrivateRoute: React.FC<Props> = ({ children }) => {
+  const navigate = useBaseNavigate()
+  const token = getAuthToken()
+
+  useEffect(() => {
+    if (!token) return
+    let active = true
+    apiFetch('/me').catch((err: any) => {
+      if (!active) return
+      if (err?.status === 401) {
+        clearAuthToken()
+        navigate('/login', { replace: true })
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [token, navigate])
+
+  if (!token) {
+    return <Navigate to="/login" replace />
+  }
+
+  return children
+}
+
+export default PrivateRoute


### PR DESCRIPTION
## Summary
- add new PrivateRoute component validating JWT lazily
- apply PrivateRoute to protected routes
- update tests to use new guard

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8a793152c83229c396204fe999869