### PR TITLE
refactor: centralize API fetch with auth

### DIFF
--- a/frontend/src/services/crud.ts
+++ b/frontend/src/services/crud.ts
@@ -1,16 +1,5 @@
-// Importa a URL base e o utilitário de token do arquivo api.ts
-import { API_BASE, getAuthToken } from './api'
-
-// Função utilitária que monta os cabeçalhos padrão com o token
-function buildHeaders(): HeadersInit {
-  // Obtém o token de autenticação salvo
-  const token = getAuthToken()
-  // Retorna os cabeçalhos incluindo Authorization se houver token
-  return {
-    'Content-Type': 'application/json', // Indica que o corpo será JSON
-    ...(token ? { Authorization: `Bearer ${token}` } : {}), // Adiciona o header apenas se existir token
-  }
-}
+// Importa a URL base e o wrapper de requisições autenticadas
+import { API_BASE, authFetch } from './api'
 
 // Trata a resposta do fetch verificando erros e convertendo para JSON
 async function handle<T>(res: Response): Promise<T> {
@@ -29,7 +18,7 @@ async function handle<T>(res: Response): Promise<T> {
 // Lista registros de um recurso específico
 export async function list<T>(resource: string): Promise<T[]> {
   // Faz requisição GET para o recurso
-  const res = await fetch(`${API_BASE}/${resource}`, { headers: buildHeaders() })
+  const res = await authFetch(`${API_BASE}/${resource}`)
   // Processa e devolve os dados
   return handle<T[]>(res)
 }
@@ -37,9 +26,8 @@ export async function list<T>(resource: string): Promise<T[]> {
 // Cria um novo registro para o recurso
 export async function create<T>(resource: string, data: any): Promise<T> {
   // Realiza requisição POST enviando o corpo em JSON
-  const res = await fetch(`${API_BASE}/${resource}`, {
+  const res = await authFetch(`${API_BASE}/${resource}`, {
     method: 'POST', // Método HTTP
-    headers: buildHeaders(), // Cabeçalhos com token
     body: JSON.stringify(data), // Corpo serializado
   })
   // Processa a resposta
@@ -49,9 +37,8 @@ export async function create<T>(resource: string, data: any): Promise<T> {
 // Atualiza um registro existente
 export async function update<T>(resource: string, id: number, data: any): Promise<T> {
   // Envia requisição PUT para o recurso/id
-  const res = await fetch(`${API_BASE}/${resource}/${id}`, {
+  const res = await authFetch(`${API_BASE}/${resource}/${id}`, {
     method: 'PUT', // Método de atualização
-    headers: buildHeaders(), // Cabeçalhos com token
     body: JSON.stringify(data), // Corpo JSON com dados
   })
   // Processa e retorna
@@ -61,9 +48,8 @@ export async function update<T>(resource: string, id: number, data: any): Promis
 // Remove um registro
 export async function remove(resource: string, id: number): Promise<void> {
   // Executa requisição DELETE no recurso/id
-  const res = await fetch(`${API_BASE}/${resource}/${id}`, {
+  const res = await authFetch(`${API_BASE}/${resource}/${id}`, {
     method: 'DELETE', // Método de exclusão
-    headers: buildHeaders(), // Cabeçalhos
   })
   // Usa handle para lançar erro caso ocorra
   await handle(res)

--- a/frontend/src/services/feriados.ts
+++ b/frontend/src/services/feriados.ts
@@ -1,5 +1,5 @@
 // Serviço para operações de feriados
-import { API_BASE, getAuthToken } from './api'
+import { API_BASE, authFetch } from './api'
 
 // Tipo de feriado utilizado na aplicação
 export interface Feriado {
@@ -10,26 +10,17 @@ export interface Feriado {
   origem: 'ESCOLA' | 'NACIONAL'
 }
 
-function headers(): HeadersInit {
-  const token = getAuthToken()
-  return {
-    'Content-Type': 'application/json',
-    ...(token ? { Authorization: `Bearer ${token}` } : {}),
-  }
-}
-
 // Busca feriados associados a um ano letivo
 export async function getFeriados(anoLetivoId: number): Promise<Feriado[]> {
-  const res = await fetch(`${API_BASE}/feriados?anoLetivoId=${anoLetivoId}`, { headers: headers() })
+  const res = await authFetch(`${API_BASE}/feriados?anoLetivoId=${anoLetivoId}`)
   if (!res.ok) throw new Error(String(res.status))
   return res.json()
 }
 
 // Cria um novo feriado
 export async function createFeriado(dto: { ano_letivo_id: number; data: string; descricao: string; origem: 'ESCOLA' }): Promise<Feriado> {
-  const res = await fetch(`${API_BASE}/feriados`, {
+  const res = await authFetch(`${API_BASE}/feriados`, {
     method: 'POST',
-    headers: headers(),
     body: JSON.stringify(dto),
   })
   if (!res.ok) throw new Error(String(res.status))
@@ -38,9 +29,8 @@ export async function createFeriado(dto: { ano_letivo_id: number; data: string; 
 
 // Atualiza feriado existente
 export async function updateFeriado(id: number, dto: { data?: string; descricao?: string }): Promise<Feriado> {
-  const res = await fetch(`${API_BASE}/feriados/${id}`, {
+  const res = await authFetch(`${API_BASE}/feriados/${id}`, {
     method: 'PUT',
-    headers: headers(),
     body: JSON.stringify(dto),
   })
   if (!res.ok) throw new Error(String(res.status))
@@ -49,15 +39,14 @@ export async function updateFeriado(id: number, dto: { data?: string; descricao?
 
 // Remove feriado
 export async function deleteFeriado(id: number): Promise<void> {
-  const res = await fetch(`${API_BASE}/feriados/${id}`, { method: 'DELETE', headers: headers() })
+  const res = await authFetch(`${API_BASE}/feriados/${id}`, { method: 'DELETE' })
   if (!res.ok) throw new Error(String(res.status))
 }
 
 // Importa feriados nacionais
 export async function importarNacionais(payload: { ano_letivo_id: number; anos: number[] }): Promise<void> {
-  const res = await fetch(`${API_BASE}/feriados/importar-nacionais`, {
+  const res = await authFetch(`${API_BASE}/feriados/importar-nacionais`, {
     method: 'POST',
-    headers: headers(),
     body: JSON.stringify(payload),
   })
   if (!res.ok) throw new Error(String(res.status))
@@ -65,7 +54,7 @@ export async function importarNacionais(payload: { ano_letivo_id: number; anos: 
 
 // Opcional: obtém feriados nacionais de um ano específico
 export async function getNacionaisStub(ano: number): Promise<Feriado[]> {
-  const res = await fetch(`${API_BASE}/feriados/nacionais?ano=${ano}`, { headers: headers() })
+  const res = await authFetch(`${API_BASE}/feriados/nacionais?ano=${ano}`)
   if (!res.ok) throw new Error(String(res.status))
   return res.json()
 }

--- a/frontend/src/services/usuariosPorGrupo.ts
+++ b/frontend/src/services/usuariosPorGrupo.ts
@@ -1,4 +1,4 @@
-import { apiRequest, API_BASE, getAuthToken } from './api'
+import { apiRequest, API_BASE, authFetch } from './api'
 
 export interface UsuarioGrupoItem {
   id_usuario: number
@@ -62,10 +62,9 @@ export async function exportarUsuariosPorGrupo(
     q: params.q,
     format,
   })
-  const token = getAuthToken()
-  const res = await fetch(`${API_BASE}/acessos/export/usuarios-por-grupo?${query}`, {
-    headers: token ? { Authorization: `Bearer ${token}` } : undefined,
-  })
+  const res = await authFetch(
+    `${API_BASE}/acessos/export/usuarios-por-grupo?${query}`,
+  )
   if (!res.ok) throw new Error('Falha na exportação')
   return res.blob()
 }


### PR DESCRIPTION
## Summary
- simplify API_BASE and token retrieval
- add authFetch wrapper with automatic JSON and Authorization headers
- refactor service helpers to use authFetch

## Testing
- `cd frontend && npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a8ab6ba49483228c6d0add35ee82d4