### PR TITLE
Implement Google OAuth callback and token persistence

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { Routes, Route, Navigate } from 'react-router-dom'
 import LoginPageWrapper from './pages/Login/LoginPageWrapper'
 import Home from './pages/Home/Home'
 import OAuthOk from './pages/OAuthOk'
+import GoogleCallback from './pages/Auth/GoogleCallback'
 
 import PoliticaDeCookies from './pages/PoliticaDeCookies'
 import PrivateRoute from './router/PrivateRoute'
@@ -22,6 +23,7 @@ const App: React.FC = () => {
       {/* Tela de login (layout travado) */}
       <Route path="/login" element={<LoginPageWrapper />} />
       <Route path="/oauth-ok" element={<OAuthOk />} />
+      <Route path="/auth/callback" element={<GoogleCallback />} />
 
       {/* Política de Cookies */}
       <Route path="/politica-de-cookies" element={<PoliticaDeCookies />} />

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -110,6 +110,8 @@ const Login: React.FC = () => {
 
   // Redireciona para o login do Google
   const handleGoogleLogin = () => {
+    const persist = keepConnected ? "1" : "0";
+    sessionStorage.setItem("login:persist", persist);
     window.location.href = `${API_BASE}/google-login`;
   };
 

--- a/frontend/src/pages/Auth/GoogleCallback.tsx
+++ b/frontend/src/pages/Auth/GoogleCallback.tsx
@@ -1,0 +1,24 @@
+import { useEffect } from 'react'
+
+const GoogleCallback: React.FC = () => {
+  useEffect(() => {
+    const hash = window.location.hash
+    const query = hash.includes('?') ? hash.split('?')[1] : ''
+    const params = new URLSearchParams(query)
+    const token = params.get('token')
+    const persist = sessionStorage.getItem('login:persist') === '1'
+    if (token) {
+      if (persist) {
+        localStorage.setItem('authToken', token)
+      } else {
+        sessionStorage.setItem('authToken', token)
+      }
+    }
+    sessionStorage.removeItem('login:persist')
+    window.location.replace('#/home')
+  }, [])
+
+  return <div>Processando login...</div>
+}
+
+export default GoogleCallback

--- a/frontend/src/pages/Configuracoes/AnoLetivo/AnoLetivo.test.tsx
+++ b/frontend/src/pages/Configuracoes/AnoLetivo/AnoLetivo.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 
 // RBAC
 test('menu e rota protegidos por role', async () => {
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   mockFetch({ '/usuarios/me': () => ({ ok: true, status: 200, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ tipo_perfil: 'professor' }), text: () => Promise.resolve('{"tipo_perfil":"professor"}') }) })
 
   render(

--- a/frontend/src/pages/Feriados/Feriados.test.tsx
+++ b/frontend/src/pages/Feriados/Feriados.test.tsx
@@ -22,7 +22,7 @@ afterEach(() => {
 
 // RBAC
 it('menu e rota protegidos por role', async () => {
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   mockFetch({ '/usuarios/me': () => ({ ok: true, status: 200, headers: { get: () => 'application/json' }, json: () => Promise.resolve({ tipo_perfil: 'professor' }), text: () => Promise.resolve('{"tipo_perfil":"professor"}') }) })
   render(
     <MemoryRouter initialEntries={['/cadastro/feriados']}>
@@ -35,7 +35,7 @@ it('menu e rota protegidos por role', async () => {
 
 // Novo feriado com erro 409
 it.skip('novo feriado mostra erro do backend', async () => {
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   mockFetch({
     '/ano-letivo': () => ({ ok: true, json: () => Promise.resolve([{ id: 1, descricao: '2024', data_inicio: '2024-01-01', data_fim: '2024-12-31' }]) }),
     '/feriados?anoLetivoId=1': () => ({ ok: true, json: () => Promise.resolve([]) }),

--- a/frontend/src/pages/Home/Home.test.tsx
+++ b/frontend/src/pages/Home/Home.test.tsx
@@ -36,7 +36,7 @@ afterEach(() => {
 
 test.skip('menu de feriados visível para diretor', async () => {
   mockPerfil('diretor')
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   render(
     <MemoryRouter initialEntries={['/home']}>
       <Home />
@@ -47,7 +47,7 @@ test.skip('menu de feriados visível para diretor', async () => {
 
 test.skip('menu de ano letivo visível para diretor', async () => {
   mockPerfil('diretor')
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   render(
     <MemoryRouter initialEntries={['/home']}>
       <Home />
@@ -58,7 +58,7 @@ test.skip('menu de ano letivo visível para diretor', async () => {
 
 test('rota de feriados bloqueada para professor', async () => {
   mockPerfil('professor')
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   render(
     <MemoryRouter initialEntries={['/cadastro/feriados']}>
       <Routes>
@@ -73,7 +73,7 @@ test('rota de feriados bloqueada para professor', async () => {
 
 test('rota de ano letivo bloqueada para professor', async () => {
   mockPerfil('professor')
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   render(
     <MemoryRouter initialEntries={['/cadastro/ano-letivo']}>
       <Routes>
@@ -88,7 +88,7 @@ test('rota de ano letivo bloqueada para professor', async () => {
 
 test('menu oculta item quando permissão ausente', async () => {
   mockPerfil('diretor', {})
-  localStorage.setItem('auth_token', 'x')
+  localStorage.setItem('authToken', 'x')
   render(
     <MemoryRouter initialEntries={['/home']}>
       <Home />

--- a/frontend/src/routes/RouteGuard.tsx
+++ b/frontend/src/routes/RouteGuard.tsx
@@ -33,11 +33,12 @@ const RouteGuard: React.FC<Props> = ({ children }) => {
   }, [navigate])
 
   useEffect(() => {
+    if (!token) return
     fetchSession()
     const handler = () => fetchSession()
     window.addEventListener('permissions:refresh', handler)
     return () => window.removeEventListener('permissions:refresh', handler)
-  }, [fetchSession])
+  }, [fetchSession, token])
 
   useEffect(() => {
     const handler = () => {


### PR DESCRIPTION
## Summary
- save persistence choice before redirecting to Google login
- add public `/auth/callback` route to store token and redirect to home
- guard routes fetch `/me` only when a token exists

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a8ae66d5e08322a39db6ed711061be