### PR TITLE
refactor: centralize API base and auth fetch

### DIFF
--- a/frontend/src/routes/RouteGuard.tsx
+++ b/frontend/src/routes/RouteGuard.tsx
@@ -17,6 +17,7 @@ const RouteGuard: React.FC<Props> = ({ children }) => {
   const [user, setUser] = useState<any>(null)
 
   const fetchSession = useCallback(async () => {
+    if (!getAuthToken()) return
     try {
       const u = await apiFetch('/me')
       const perms = await apiFetch('/me/permissions/effective')
@@ -33,11 +34,12 @@ const RouteGuard: React.FC<Props> = ({ children }) => {
   }, [navigate])
 
   useEffect(() => {
+    if (!token) return
     fetchSession()
     const handler = () => fetchSession()
     window.addEventListener('permissions:refresh', handler)
     return () => window.removeEventListener('permissions:refresh', handler)
-  }, [fetchSession])
+  }, [fetchSession, token])
 
   useEffect(() => {
     const handler = () => {

--- a/frontend/src/services/crud.ts
+++ b/frontend/src/services/crud.ts
@@ -1,5 +1,5 @@
-// Importa a URL base e o wrapper de requisições autenticadas
-import { API_BASE, authFetch } from './api'
+// Importa o wrapper de requisições autenticadas
+import { authFetch } from './api'
 
 // Trata a resposta do fetch verificando erros e convertendo para JSON
 async function handle<T>(res: Response): Promise<T> {
@@ -18,7 +18,7 @@ async function handle<T>(res: Response): Promise<T> {
 // Lista registros de um recurso específico
 export async function list<T>(resource: string): Promise<T[]> {
   // Faz requisição GET para o recurso
-  const res = await authFetch(`${API_BASE}/${resource}`)
+  const res = await authFetch(`/${resource}`)
   // Processa e devolve os dados
   return handle<T[]>(res)
 }
@@ -26,7 +26,7 @@ export async function list<T>(resource: string): Promise<T[]> {
 // Cria um novo registro para o recurso
 export async function create<T>(resource: string, data: any): Promise<T> {
   // Realiza requisição POST enviando o corpo em JSON
-  const res = await authFetch(`${API_BASE}/${resource}`, {
+  const res = await authFetch(`/${resource}`, {
     method: 'POST', // Método HTTP
     body: JSON.stringify(data), // Corpo serializado
   })
@@ -37,7 +37,7 @@ export async function create<T>(resource: string, data: any): Promise<T> {
 // Atualiza um registro existente
 export async function update<T>(resource: string, id: number, data: any): Promise<T> {
   // Envia requisição PUT para o recurso/id
-  const res = await authFetch(`${API_BASE}/${resource}/${id}`, {
+  const res = await authFetch(`/${resource}/${id}`, {
     method: 'PUT', // Método de atualização
     body: JSON.stringify(data), // Corpo JSON com dados
   })
@@ -48,7 +48,7 @@ export async function update<T>(resource: string, id: number, data: any): Promis
 // Remove um registro
 export async function remove(resource: string, id: number): Promise<void> {
   // Executa requisição DELETE no recurso/id
-  const res = await authFetch(`${API_BASE}/${resource}/${id}`, {
+  const res = await authFetch(`/${resource}/${id}`, {
     method: 'DELETE', // Método de exclusão
   })
   // Usa handle para lançar erro caso ocorra

--- a/frontend/src/services/feriados.ts
+++ b/frontend/src/services/feriados.ts
@@ -1,5 +1,5 @@
 // Serviço para operações de feriados
-import { API_BASE, authFetch } from './api'
+import { authFetch } from './api'
 
 // Tipo de feriado utilizado na aplicação
 export interface Feriado {
@@ -12,14 +12,14 @@ export interface Feriado {
 
 // Busca feriados associados a um ano letivo
 export async function getFeriados(anoLetivoId: number): Promise<Feriado[]> {
-  const res = await authFetch(`${API_BASE}/feriados?anoLetivoId=${anoLetivoId}`)
+  const res = await authFetch(`/feriados?anoLetivoId=${anoLetivoId}`)
   if (!res.ok) throw new Error(String(res.status))
   return res.json()
 }
 
 // Cria um novo feriado
 export async function createFeriado(dto: { ano_letivo_id: number; data: string; descricao: string; origem: 'ESCOLA' }): Promise<Feriado> {
-  const res = await authFetch(`${API_BASE}/feriados`, {
+  const res = await authFetch(`/feriados`, {
     method: 'POST',
     body: JSON.stringify(dto),
   })
@@ -29,7 +29,7 @@ export async function createFeriado(dto: { ano_letivo_id: number; data: string; 
 
 // Atualiza feriado existente
 export async function updateFeriado(id: number, dto: { data?: string; descricao?: string }): Promise<Feriado> {
-  const res = await authFetch(`${API_BASE}/feriados/${id}`, {
+  const res = await authFetch(`/feriados/${id}`, {
     method: 'PUT',
     body: JSON.stringify(dto),
   })
@@ -39,13 +39,13 @@ export async function updateFeriado(id: number, dto: { data?: string; descricao?
 
 // Remove feriado
 export async function deleteFeriado(id: number): Promise<void> {
-  const res = await authFetch(`${API_BASE}/feriados/${id}`, { method: 'DELETE' })
+  const res = await authFetch(`/feriados/${id}`, { method: 'DELETE' })
   if (!res.ok) throw new Error(String(res.status))
 }
 
 // Importa feriados nacionais
 export async function importarNacionais(payload: { ano_letivo_id: number; anos: number[] }): Promise<void> {
-  const res = await authFetch(`${API_BASE}/feriados/importar-nacionais`, {
+  const res = await authFetch(`/feriados/importar-nacionais`, {
     method: 'POST',
     body: JSON.stringify(payload),
   })
@@ -54,7 +54,7 @@ export async function importarNacionais(payload: { ano_letivo_id: number; anos: 
 
 // Opcional: obtém feriados nacionais de um ano específico
 export async function getNacionaisStub(ano: number): Promise<Feriado[]> {
-  const res = await authFetch(`${API_BASE}/feriados/nacionais?ano=${ano}`)
+  const res = await authFetch(`/feriados/nacionais?ano=${ano}`)
   if (!res.ok) throw new Error(String(res.status))
   return res.json()
 }

--- a/frontend/src/services/usuariosPorGrupo.ts
+++ b/frontend/src/services/usuariosPorGrupo.ts
@@ -1,4 +1,4 @@
-import { apiRequest, API_BASE, authFetch } from './api'
+import { apiRequest, authFetch } from './api'
 
 export interface UsuarioGrupoItem {
   id_usuario: number
@@ -63,7 +63,7 @@ export async function exportarUsuariosPorGrupo(
     format,
   })
   const res = await authFetch(
-    `${API_BASE}/acessos/export/usuarios-por-grupo?${query}`,
+    `/acessos/export/usuarios-por-grupo?${query}`,
   )
   if (!res.ok) throw new Error('Falha na exportação')
   return res.blob()


### PR DESCRIPTION
## Summary
- centralize API_BASE from Vite env and wrap authFetch to prefix paths and send bearer tokens
- avoid calling /me without a stored token and use authFetch across services
- remove hardcoded API URLs in feriados, CRUD, and export services

## Testing
- `npm test` *(fails: Unable to find an element with the text: Bem-vindo ao Portal do Professor)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ae8007588322ac9f51041c3a18d5