### PR TITLE
feat: handle auth callback and secure menus

### DIFF
--- a/frontend/src/pages/Auth/GoogleCallback.tsx
+++ b/frontend/src/pages/Auth/GoogleCallback.tsx
@@ -1,24 +1,21 @@
 import { useEffect } from 'react'
 
-const GoogleCallback: React.FC = () => {
+export default function GoogleCallback() {
   useEffect(() => {
-    const hash = window.location.hash
-    const query = hash.includes('?') ? hash.split('?')[1] : ''
-    const params = new URLSearchParams(query)
+    // Ex.: "#/auth/callback?token=...&t=..."
+    const hash = window.location.hash || ''
+    const qs = hash.split('?')[1] || ''
+    const params = new URLSearchParams(qs)
     const token = params.get('token')
     const persist = sessionStorage.getItem('login:persist') === '1'
     if (token) {
-      if (persist) {
-        localStorage.setItem('authToken', token)
-      } else {
-        sessionStorage.setItem('authToken', token)
-      }
+      if (persist) localStorage.setItem('authToken', token)
+      else sessionStorage.setItem('authToken', token)
     }
     sessionStorage.removeItem('login:persist')
     window.location.replace('#/home')
   }, [])
 
-  return <div>Processando login...</div>
+  return null
 }
 
-export default GoogleCallback

--- a/frontend/src/pages/Configuracoes/AnoLetivo/AnoLetivo.test.tsx
+++ b/frontend/src/pages/Configuracoes/AnoLetivo/AnoLetivo.test.tsx
@@ -31,7 +31,7 @@ test('menu e rota protegidos por role', async () => {
     </MemoryRouter>
   )
 
-  expect(await screen.findByText('Bem-vindo ao Portal do Professor')).toBeInTheDocument()
+  expect(await screen.findByText('403 - Acesso negado')).toBeInTheDocument()
   expect(screen.queryByText('Cadastro')).not.toBeInTheDocument()
 })
 

--- a/frontend/src/pages/Feriados/Feriados.test.tsx
+++ b/frontend/src/pages/Feriados/Feriados.test.tsx
@@ -29,7 +29,7 @@ it('menu e rota protegidos por role', async () => {
       <App />
     </MemoryRouter>
   )
-  expect(await screen.findByText('Bem-vindo ao Portal do Professor')).toBeInTheDocument()
+  expect(await screen.findByText('403 - Acesso negado')).toBeInTheDocument()
   expect(screen.queryByText('Cadastro')).not.toBeInTheDocument()
 })
 

--- a/frontend/src/pages/Home/Home.test.tsx
+++ b/frontend/src/pages/Home/Home.test.tsx
@@ -11,22 +11,23 @@ function mockPerfil(perfil: string, perms?: Record<string, Record<string, boolea
     (perfil === 'diretor'
       ? {
           '/cadastro/feriados': { view: true },
-          '/cadastro/ano-letivo': { view: true }
+          '/cadastro/ano-letivo': { view: true },
         }
       : {})
-  global.fetch = vi.fn((url: string) => {
-    const body = url.includes('/permissions/effective')
-      ? effective
-      : { tipo_perfil: perfil, is_master: perfil === 'master' }
+  global.fetch = vi.fn(() => {
+    const body = {
+      perfis: [perfil],
+      permissoes: effective,
+      is_master: perfil === 'master',
+    }
     return Promise.resolve({
       ok: true,
       status: 200,
       headers: { get: () => 'application/json' } as any,
       json: () => Promise.resolve(body),
-      text: () => Promise.resolve(JSON.stringify(body))
+      text: () => Promise.resolve(JSON.stringify(body)),
     }) as any
   })
-  localStorage.setItem('permissions.effective', JSON.stringify(effective))
 }
 
 afterEach(() => {
@@ -67,7 +68,9 @@ test('rota de feriados bloqueada para professor', async () => {
       </Routes>
     </MemoryRouter>
   )
-  await waitFor(() => expect(screen.getByText('Bem-vindo ao Portal do Professor')).toBeInTheDocument())
+  await waitFor(() =>
+    expect(screen.getByText('403 - Acesso negado')).toBeInTheDocument(),
+  )
   expect(screen.queryByText('Cadastro de Feriados')).not.toBeInTheDocument()
 })
 
@@ -82,7 +85,9 @@ test('rota de ano letivo bloqueada para professor', async () => {
       </Routes>
     </MemoryRouter>
   )
-  await waitFor(() => expect(screen.getByText('Bem-vindo ao Portal do Professor')).toBeInTheDocument())
+  await waitFor(() =>
+    expect(screen.getByText('403 - Acesso negado')).toBeInTheDocument(),
+  )
   expect(screen.queryByText('Cadastro de Ano Letivo')).not.toBeInTheDocument()
 })
 


### PR DESCRIPTION
## Summary
- save Google OAuth tokens and persistence choice on the callback route
- load user permissions from `/me` and display a 403 page when unauthorized
- adjust tests for new permission enforcement

## Testing
- `npm --prefix frontend test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68a8b67f02a083229f9b97c67d726723