### PR TITLE
feat: persist tokens and validate session once

### DIFF
--- a/frontend/src/router/PrivateRoute.tsx
+++ b/frontend/src/router/PrivateRoute.tsx
@@ -13,17 +13,22 @@ interface Props {
  * - Com token: renderiza children e valida /me de forma lazy
  * - 401 no /me: limpa storage e redireciona para login
  */
+let validatedToken: string | null = null
+
 const PrivateRoute: React.FC<Props> = ({ children }) => {
   const navigate = useBaseNavigate()
   const token = getAuthToken()
 
   useEffect(() => {
     if (!token) return
+    if (validatedToken === token) return
     let active = true
+    validatedToken = token
     apiFetch('/me').catch((err: any) => {
       if (!active) return
       if (err?.status === 401) {
         clearAuthToken()
+        validatedToken = null
         navigate('/login', { replace: true })
       }
     })


### PR DESCRIPTION
## Summary
- ensure PrivateRoute validates token against `/me` only once per session

## Testing
- `npm test`
- `rg -n "localhost|127.0.0.1|0.0.0.0" frontend/src && echo "❌ Ainda há localhost no frontend" && exit 1 || echo "✅ Frontend sem localhost"`


------
https://chatgpt.com/codex/tasks/task_e_68a8beb1d2688322b0a24246fd3d1106