### PR TITLE
refactor: centralize API auth helpers

### DIFF
--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -7,7 +7,7 @@ import useBaseNavigate from '@/hooks/useBaseNavigate'
 import '../../styles/Home.css'
 import '../../styles/Home.lock.css'
 import { loadThemeFromStorage } from '../../theme/utils'
-import { apiFetch, getAuthToken, logoutLocal } from '@/services/api'
+import { authFetch, getAuthToken, logoutLocal } from '@/services/api'
 
 const toCanonical = (perfil: string) => (perfil || '').toLowerCase()
 
@@ -83,9 +83,10 @@ const Home: React.FC = () => {
     const token = getAuthToken()
     if (!token) { navigate('/login'); return }
 
-    apiFetch('/me')
-      .then((data: any) => {
-        if (!data) return
+    authFetch('/me', { method: 'GET' })
+      .then(async (res) => {
+        if (!res.ok) throw new Error()
+        const data: any = await res.json()
         const { perfis = [], permissoes = {}, id_usuario, id } = data
         setIsMaster(perfis.map(toCanonical).includes('master'))
         setPermissions(permissoes)
@@ -119,7 +120,7 @@ const Home: React.FC = () => {
 
   // Logout
   const handleLogout = useCallback(() => {
-    apiFetch('/logout', { method: 'POST' }).catch(() => {})
+    authFetch('/logout', { method: 'POST' }).catch(() => {})
     logoutLocal()
     try { localStorage.removeItem('permissions.effective') } catch {}
     navigate('/login')

--- a/frontend/src/pages/Logs/Logs.tsx
+++ b/frontend/src/pages/Logs/Logs.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import useBaseNavigate from '@/hooks/useBaseNavigate'
-import { apiFetch } from '@/services/api'
+import { authFetch } from '@/services/api'
 import LogsConfig from './LogsConfig'
 import LogsOverview from './LogsOverview'
 import '../../styles/Logs.css'
@@ -33,8 +33,12 @@ const Logs: React.FC = () => {
     if (dataInicio) params.data_inicio = dataInicio
     if (dataFim) params.data_fim = dataFim
     const qs = new URLSearchParams(params).toString()
-    apiFetch(`/logs${qs ? `?${qs}` : ''}`)
-      .then((r: any) => setLogs(r))
+    authFetch(`/logs${qs ? `?${qs}` : ''}`, { method: 'GET' })
+      .then(async (res) => {
+        if (!res.ok) throw new Error()
+        const r: any = await res.json()
+        setLogs(r)
+      })
       .catch(() => setLogs([]))
   }
 

--- a/frontend/src/router/PrivateRoute.tsx
+++ b/frontend/src/router/PrivateRoute.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Navigate } from 'react-router-dom'
-import { apiFetch, getAuthToken, clearAuthToken } from '@/services/api'
+import { authFetch, getAuthToken, clearAuthToken } from '@/services/api'
 import useBaseNavigate from '@/hooks/useBaseNavigate'
 
 interface Props {
@@ -20,13 +20,15 @@ const PrivateRoute: React.FC<Props> = ({ children }) => {
   useEffect(() => {
     if (!token) return
     let active = true
-    apiFetch('/me').catch((err: any) => {
-      if (!active) return
-      if (err?.status === 401) {
-        clearAuthToken()
-        navigate('/login', { replace: true })
-      }
-    })
+    authFetch('/me', { method: 'GET' })
+      .then(res => {
+        if (!active) return
+        if (res.status === 401) {
+          clearAuthToken()
+          navigate('/login', { replace: true })
+        }
+      })
+      .catch(() => {})
     return () => {
       active = false
     }

--- a/frontend/src/routes/RouteGuard.tsx
+++ b/frontend/src/routes/RouteGuard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react'
 import { Navigate, useLocation } from 'react-router-dom'
-import { apiFetch, getAuthToken, clearAuthToken } from '@/services/api'
+import { authFetch, getAuthToken, clearAuthToken } from '@/services/api'
 import useBaseNavigate from '@/hooks/useBaseNavigate'
 
 interface Props {
@@ -19,8 +19,12 @@ const RouteGuard: React.FC<Props> = ({ children }) => {
   const fetchSession = useCallback(async () => {
     if (!getAuthToken()) return
     try {
-      const u = await apiFetch('/me')
-      const perms = await apiFetch('/me/permissions/effective')
+      const uRes = await authFetch('/me', { method: 'GET' })
+      if (!uRes.ok) throw new Error()
+      const u = await uRes.json()
+      const pRes = await authFetch('/me/permissions/effective', { method: 'GET' })
+      if (!pRes.ok) throw new Error()
+      const perms = await pRes.json()
       setUser(u)
       setPermissions(perms)
       try { localStorage.setItem('permissions.effective', JSON.stringify(perms)) } catch {}

--- a/frontend/src/services/apiLogs.ts
+++ b/frontend/src/services/apiLogs.ts
@@ -1,22 +1,27 @@
-import { apiFetch } from './api'
+import { authFetch } from './api'
 
 export type LogFlags = { create:boolean; read:boolean; update:boolean; delete:boolean }
 export type LogConfigOut = LogFlags & { screen:string; updated_at:string; updated_by_name:string }
 
 export async function fetchScreens(): Promise<Array<{key:string; label:string}>> {
-  return apiFetch('/logs/config/screens')
+  const res = await authFetch('/logs/config/screens', { method: 'GET' })
+  if (!res.ok) throw new Error()
+  return res.json()
 }
 
 export async function fetchLogConfig(screen:string): Promise<LogConfigOut> {
-  return apiFetch(`/logs/config?screen=${encodeURIComponent(screen)}`)
+  const res = await authFetch(`/logs/config?screen=${encodeURIComponent(screen)}`, { method: 'GET' })
+  if (!res.ok) throw new Error()
+  return res.json()
 }
 
 export async function saveLogConfig(body: {screen:string}&LogFlags&{applyAll?:boolean}): Promise<LogConfigOut> {
-  return apiFetch('/logs/config', {
+  const res = await authFetch('/logs/config', {
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   })
+  if (!res.ok) throw new Error()
+  return res.json()
 }
 
 export type SummaryRow = {
@@ -31,6 +36,8 @@ export async function fetchLogsSummary(params: {page?:number; pageSize?:number; 
     if (v !== undefined && v !== null && v !== '') urlParams.set(k, String(v))
   })
   const qs = urlParams.toString()
-  return apiFetch(`/logs/summary${qs ? `?${qs}` : ''}`)
+  const res = await authFetch(`/logs/summary${qs ? `?${qs}` : ''}`, { method: 'GET' })
+  if (!res.ok) throw new Error()
+  return res.json()
 }
 

--- a/frontend/src/services/logs.ts
+++ b/frontend/src/services/logs.ts
@@ -1,4 +1,4 @@
-import { apiFetch } from './api'
+import { authFetch } from './api'
 
 
 export interface LogConfigPayload {
@@ -8,11 +8,11 @@ export interface LogConfigPayload {
 
 export async function cadastrarConfig(data: LogConfigPayload): Promise<void> {
   try {
-    await apiFetch('/logs/config', {
+    const res = await authFetch('/logs/config', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(data),
     })
+    if (!res.ok) throw new Error()
   } catch (e: any) {
     throw new Error(e?.message || 'Erro ao salvar configuração')
   }


### PR DESCRIPTION
## Summary
- centralize API base and auth helpers
- use authFetch for protected endpoints and avoid /me without token
- convert logs utilities to authFetch

## Testing
- `cd frontend && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a8bebff99483228a259c55c661462f