### PR TITLE
feat: add theme tokens and preferences api

### DIFF
--- a/backend/migrations/versions/fd3e8b2e4b4e_add_preferences_to_usuarios.py
+++ b/backend/migrations/versions/fd3e8b2e4b4e_add_preferences_to_usuarios.py
@@ -1,0 +1,21 @@
+"""add preferences column to usuarios
+
+Revision ID: fd3e8b2e4b4e
+Revises: c64b1f765a7b
+Create Date: 2024-05-30
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'fd3e8b2e4b4e'
+down_revision = 'c64b1f765a7b'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.add_column('usuarios', sa.Column('preferences', sa.JSON(), nullable=False, server_default=sa.text('{}')))
+
+
+def downgrade():
+    op.drop_column('usuarios', 'preferences')

--- a/backend/models/usuarios.py
+++ b/backend/models/usuarios.py
@@ -1,7 +1,7 @@
 # backend/models/usuarios.py
 
 # Importa os tipos de coluna do SQLAlchemy
-from sqlalchemy import Column, Integer, String, Boolean, DateTime
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, JSON
 
 # Importa datetime para timestamps
 from datetime import datetime
@@ -52,3 +52,6 @@ class Usuarios(Base):
 
     # Timestamp de atualização do usuário
     atualizado_em = Column(DateTime, nullable=True, default=None)
+
+    # Preferências do usuário (ex.: tema da interface)
+    preferences = Column(JSON, nullable=False, default=dict)

--- a/backend/routes/me.py
+++ b/backend/routes/me.py
@@ -6,6 +6,9 @@ from backend.database import get_db
 from backend.security import get_current_user
 from backend.services.permissions import get_effective_permissions
 from backend.routes.usuarios import token_data_from_request, to_canonical
+from backend.schemas.theme import ThemePreferences
+from backend.models.usuarios import Usuarios
+from backend.utils.audit import registrar_log
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -46,4 +49,38 @@ def effective_permissions(request: Request, db: Session = Depends(get_db)):
         "role": role,
         "permissions": perms,
     }
+
+
+@router.get("/me/preferences/theme")
+def get_theme_preferences(
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    usuario = db.query(Usuarios).filter(Usuarios.id_usuario == current_user["id"]).first()
+    prefs = usuario.preferences or {}
+    return {
+        "themeName": prefs.get("themeName", "roxo"),
+        "themeMode": prefs.get("themeMode", "light"),
+    }
+
+
+@router.put("/me/preferences/theme")
+def set_theme_preferences(
+    prefs: ThemePreferences,
+    current_user: dict = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    usuario = db.query(Usuarios).filter(Usuarios.id_usuario == current_user["id"]).first()
+    before = usuario.preferences or {}
+    usuario.preferences = {**before, "themeName": prefs.themeName, "themeMode": prefs.themeMode}
+    db.commit()
+    registrar_log(
+        db,
+        current_user["id"],
+        "update",
+        "usuario.theme",
+        id_referencia=current_user["id"],
+        descricao=f"theme {before} -> {{'themeName': '{prefs.themeName}', 'themeMode': '{prefs.themeMode}'}}",
+    )
+    return {"themeName": prefs.themeName, "themeMode": prefs.themeMode}
 

--- a/backend/schemas/theme.py
+++ b/backend/schemas/theme.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel, field_validator
+
+VALID_THEMES = {'roxo','vermelho','azul','verde','laranja','cinza','rosa','ciano'}
+VALID_MODES = {'light','dark'}
+
+class ThemePreferences(BaseModel):
+    themeName: str
+    themeMode: str
+
+    @field_validator('themeName')
+    def validate_theme(cls, v):
+        if v not in VALID_THEMES:
+            raise ValueError('invalid theme')
+        return v
+
+    @field_validator('themeMode')
+    def validate_mode(cls, v):
+        if v not in VALID_MODES:
+            raise ValueError('invalid mode')
+        return v

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,32 +3,6 @@
   <head>
     <!-- Define o charset como UTF-8 para suporte a caracteres especiais -->
     <meta charset="UTF-8" />
-      <script>
-        (function () {
-          var root = document.documentElement;
-          var COLORS = {
-            roxo: '#6D28D9',
-            vermelho: '#EF4444',
-            azul: '#3B82F6',
-            verde: '#10B981',
-            laranja: '#F59E0B',
-            cinza: '#6B7280',
-            rosa: '#EC4899',
-            ciano: '#06B6D4'
-          };
-          var theme = localStorage.getItem('theme') || 'roxo';
-          var mode = localStorage.getItem('mode') || 'light';
-          root.setAttribute('data-theme', theme);
-          root.setAttribute('data-mode', mode);
-          var meta = document.querySelector('meta[name="theme-color"]');
-          if (!meta) {
-            meta = document.createElement('meta');
-            meta.setAttribute('name', 'theme-color');
-            document.head.appendChild(meta);
-          }
-          meta.setAttribute('content', COLORS[theme] || COLORS['roxo']);
-        })();
-      </script>
       <!-- Define como o site deve se comportar em dispositivos móveis -->
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
@@ -45,7 +19,7 @@
     <!-- Título da aba do navegador -->
     <title>Portal do Professor</title>
   </head>
-  <body>
+  <body data-theme="roxo" data-mode="light">
     <!-- Container onde a aplicação React será injetada -->
     <div id="root"></div>
 

--- a/frontend/src/pages/Configuracoes/ConfigurarTema.tsx
+++ b/frontend/src/pages/Configuracoes/ConfigurarTema.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import '../../styles/ConfigTema.css'
 import { applyTheme, loadThemeFromStorage, saveTheme, saveMode, THEME_OPTIONS, ThemeName, ModeKey } from '../../theme/utils'
+import { put } from '../../services/http'
 
 const ConfigurarTema: React.FC = () => {
   const [selectedTheme, setSelectedTheme] = useState<ThemeName>('roxo')
@@ -13,10 +14,15 @@ const ConfigurarTema: React.FC = () => {
     setSelectedMode(mode)
   }, [])
 
-  const handleSalvar = () => {
+  const handleSalvar = async () => {
     saveTheme(selectedTheme)
     saveMode(selectedMode)
     applyTheme(selectedTheme, selectedMode)
+    try {
+      await put('/me/preferences/theme', { themeName: selectedTheme, themeMode: selectedMode })
+    } catch {
+      // ignore errors silently
+    }
     setShowToast(true)
     setTimeout(() => setShowToast(false), 2000)
   }
@@ -50,13 +56,13 @@ const ConfigurarTema: React.FC = () => {
 
       <div className="theme-preview" data-preview-theme={selectedTheme} data-preview-mode={selectedMode}>
         <div className="preview-header"></div>
-          <button className="btn btn-md">Botão Primário</button>
+          <button className="btn btn-md btn-primary">Botão Primário</button>
       </div>
 
       {showToast && <div className="toast-success">Tema alterado com sucesso</div>}
 
       <div className="theme-actions">
-          <button className="btn btn-md" onClick={handleSalvar}>Salvar alterações</button>
+          <button className="btn btn-md btn-primary" onClick={handleSalvar}>Salvar alterações</button>
       </div>
     </section>
   )

--- a/frontend/src/styles/ConfigTema.css
+++ b/frontend/src/styles/ConfigTema.css
@@ -10,16 +10,16 @@
   border-radius: 12px;
   border: 2px solid var(--border);
   cursor: pointer;
-  background: var(--primary);
+  background: var(--color-primary);
 }
-.theme-swatch.roxo      { --primary: #6D28D9; --on-primary: #ffffff; }
-.theme-swatch.vermelho  { --primary: #EF4444; --on-primary: #ffffff; }
-.theme-swatch.azul      { --primary: #3B82F6; --on-primary: #ffffff; }
-.theme-swatch.verde     { --primary: #10B981; --on-primary: #ffffff; }
-.theme-swatch.laranja   { --primary: #F59E0B; --on-primary: #111827; }
-.theme-swatch.cinza     { --primary: #6B7280; --on-primary: #ffffff; }
-.theme-swatch.rosa      { --primary: #EC4899; --on-primary: #ffffff; }
-.theme-swatch.ciano     { --primary: #06B6D4; --on-primary: #ffffff; }
+.theme-swatch.roxo      { --color-primary: var(--theme-roxo); }
+.theme-swatch.vermelho  { --color-primary: var(--theme-vermelho); }
+.theme-swatch.azul      { --color-primary: var(--theme-azul); }
+.theme-swatch.verde     { --color-primary: var(--theme-verde); }
+.theme-swatch.laranja   { --color-primary: var(--theme-laranja); }
+.theme-swatch.cinza     { --color-primary: var(--theme-cinza); }
+.theme-swatch.rosa      { --color-primary: var(--theme-rosa); }
+.theme-swatch.ciano     { --color-primary: var(--theme-ciano); }
 
 .theme-swatch.selected {
   outline: 3px solid var(--primary);
@@ -46,27 +46,27 @@
 }
 
 .theme-preview[data-preview-mode='light'] {
-  --bg: #ffffff;
-  --text: #111827;
-  --surface: #f5f7fb;
-  --border: #e5e7eb;
+  --bg: var(--mode-light-bg);
+  --text: var(--mode-light-text);
+  --surface: var(--mode-light-surface);
+  --border: var(--mode-light-border);
 }
 
 .theme-preview[data-preview-mode='dark'] {
-  --bg: #0f172a;
-  --text: #e5e7eb;
-  --surface: #111827;
-  --border: #1f2937;
+  --bg: var(--mode-dark-bg);
+  --text: var(--mode-dark-text);
+  --surface: var(--mode-dark-surface);
+  --border: var(--mode-dark-border);
 }
 
-.theme-preview[data-preview-theme='roxo']     { --primary: #6D28D9; --on-primary: #ffffff; }
-.theme-preview[data-preview-theme='vermelho'] { --primary: #EF4444; --on-primary: #ffffff; }
-.theme-preview[data-preview-theme='azul']     { --primary: #3B82F6; --on-primary: #ffffff; }
-.theme-preview[data-preview-theme='verde']    { --primary: #10B981; --on-primary: #ffffff; }
-.theme-preview[data-preview-theme='laranja']  { --primary: #F59E0B; --on-primary: #111827; }
-.theme-preview[data-preview-theme='cinza']    { --primary: #6B7280; --on-primary: #ffffff; }
-.theme-preview[data-preview-theme='rosa']     { --primary: #EC4899; --on-primary: #ffffff; }
-.theme-preview[data-preview-theme='ciano']    { --primary: #06B6D4; --on-primary: #ffffff; }
+.theme-preview[data-preview-theme='roxo']     { --primary: var(--theme-roxo); --on-primary: var(--theme-roxo-on); }
+.theme-preview[data-preview-theme='vermelho'] { --primary: var(--theme-vermelho); --on-primary: var(--theme-vermelho-on); }
+.theme-preview[data-preview-theme='azul']     { --primary: var(--theme-azul); --on-primary: var(--theme-azul-on); }
+.theme-preview[data-preview-theme='verde']    { --primary: var(--theme-verde); --on-primary: var(--theme-verde-on); }
+.theme-preview[data-preview-theme='laranja']  { --primary: var(--theme-laranja); --on-primary: var(--theme-laranja-on); }
+.theme-preview[data-preview-theme='cinza']    { --primary: var(--theme-cinza); --on-primary: var(--theme-cinza-on); }
+.theme-preview[data-preview-theme='rosa']     { --primary: var(--theme-rosa); --on-primary: var(--theme-rosa-on); }
+.theme-preview[data-preview-theme='ciano']    { --primary: var(--theme-ciano); --on-primary: var(--theme-ciano-on); }
 
 .theme-preview .preview-header {
   height: 44px;
@@ -80,8 +80,6 @@
 }
 
 .toast-success {
-  background: var(--primary);
-  color: var(--on-primary);
   padding: .5rem .75rem;
   border-radius: .5rem;
 }

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -8,6 +8,11 @@
   --border: #e2e2e8;
   --btn-radius: .75rem;
   --btn-shadow: 0 2px 4px rgba(0,0,0,0.1);
+  --color-primary: var(--primary);
+  --color-on-primary: var(--on-primary);
+  --color-success: #16a34a;
+  --color-error: #dc2626;
+  --color-white: #ffffff;
 
   /* aliases for legacy variables */
   --primary-color: var(--primary);
@@ -22,6 +27,34 @@
   --pp-muted: color-mix(in srgb, var(--text) 60%, var(--bg));
   --pp-danger: #e53e3e;
   --pp-shadow: var(--btn-shadow);
+
+  /* theme color tokens */
+  --theme-roxo: #6D28D9;
+  --theme-roxo-on: #ffffff;
+  --theme-vermelho: #EF4444;
+  --theme-vermelho-on: #ffffff;
+  --theme-azul: #3B82F6;
+  --theme-azul-on: #ffffff;
+  --theme-verde: #10B981;
+  --theme-verde-on: #ffffff;
+  --theme-laranja: #F59E0B;
+  --theme-laranja-on: #111827;
+  --theme-cinza: #6B7280;
+  --theme-cinza-on: #ffffff;
+  --theme-rosa: #EC4899;
+  --theme-rosa-on: #ffffff;
+  --theme-ciano: #06B6D4;
+  --theme-ciano-on: #ffffff;
+
+  /* mode base colors for previews */
+  --mode-light-bg: #ffffff;
+  --mode-light-text: #111827;
+  --mode-light-surface: #f5f7fb;
+  --mode-light-border: #e5e7eb;
+  --mode-dark-bg: #0f172a;
+  --mode-dark-text: #e5e7eb;
+  --mode-dark-surface: #111827;
+  --mode-dark-border: #1f2937;
 }
 
 :root[data-mode="dark"] {
@@ -35,14 +68,14 @@
 }
 
 /* theme maps */
-:root[data-theme="roxo"]     { --primary: #6D28D9; --on-primary: #ffffff; }
-:root[data-theme="vermelho"] { --primary: #EF4444; --on-primary: #ffffff; }
-:root[data-theme="azul"]     { --primary: #3B82F6; --on-primary: #ffffff; }
-:root[data-theme="verde"]    { --primary: #10B981; --on-primary: #ffffff; }
-:root[data-theme="laranja"]  { --primary: #F59E0B; --on-primary: #111827; }
-:root[data-theme="cinza"]    { --primary: #6B7280; --on-primary: #ffffff; }
-:root[data-theme="rosa"]     { --primary: #EC4899; --on-primary: #ffffff; }
-:root[data-theme="ciano"]    { --primary: #06B6D4; --on-primary: #ffffff; }
+:root[data-theme="roxo"]     { --primary: var(--theme-roxo); --on-primary: var(--theme-roxo-on); }
+:root[data-theme="vermelho"] { --primary: var(--theme-vermelho); --on-primary: var(--theme-vermelho-on); }
+:root[data-theme="azul"]     { --primary: var(--theme-azul); --on-primary: var(--theme-azul-on); }
+:root[data-theme="verde"]    { --primary: var(--theme-verde); --on-primary: var(--theme-verde-on); }
+:root[data-theme="laranja"]  { --primary: var(--theme-laranja); --on-primary: var(--theme-laranja-on); }
+:root[data-theme="cinza"]    { --primary: var(--theme-cinza); --on-primary: var(--theme-cinza-on); }
+:root[data-theme="rosa"]     { --primary: var(--theme-rosa); --on-primary: var(--theme-rosa-on); }
+:root[data-theme="ciano"]    { --primary: var(--theme-ciano); --on-primary: var(--theme-ciano-on); }
 
 
 .card, .menu, .header {
@@ -91,4 +124,21 @@
 .app-bg      { background: var(--bg);    color: var(--text); }
 .app-surface { background: var(--surface); }
 .app-border  { border: 1px solid var(--border); }
+
+/* utility buttons */
+.btn-primary {
+  background: var(--color-primary);
+  color: var(--color-on-primary);
+  border: 1px solid transparent;
+  border-radius: var(--btn-radius);
+}
+
+.btn-primary:hover {
+  filter: brightness(0.92);
+}
+
+.toast-success {
+  background: var(--color-success);
+  color: var(--color-white);
+}
 

--- a/frontend/src/theme/utils.test.ts
+++ b/frontend/src/theme/utils.test.ts
@@ -4,19 +4,19 @@ import { loadThemeFromStorage, saveTheme, saveMode, applyTheme } from './utils'
 describe('utils de tema', () => {
   beforeEach(() => {
     localStorage.clear()
-    const root = document.documentElement
-    root.removeAttribute('data-theme')
-    root.removeAttribute('data-mode')
+    const body = document.body
+    body.removeAttribute('data-theme')
+    body.removeAttribute('data-mode')
   })
 
   it('carrega padrão quando storage vazio', () => {
     const { theme, mode } = loadThemeFromStorage()
-    const root = document.documentElement
-    expect(theme).toBe('default')
+    const body = document.body
+    expect(theme).toBe('roxo')
     expect(mode).toBe('light')
-    expect(root.getAttribute('data-theme')).toBe('default')
-    expect(root.getAttribute('data-mode')).toBe('light')
-    expect(localStorage.getItem('theme')).toBe('default')
+    expect(body.getAttribute('data-theme')).toBe('roxo')
+    expect(body.getAttribute('data-mode')).toBe('light')
+    expect(localStorage.getItem('theme')).toBe('roxo')
     expect(localStorage.getItem('mode')).toBe('light')
   })
 
@@ -25,13 +25,13 @@ describe('utils de tema', () => {
     saveMode('dark')
     applyTheme('vermelho', 'dark')
     const { theme, mode } = loadThemeFromStorage()
-    const root = document.documentElement
+    const body = document.body
     expect(theme).toBe('vermelho')
     expect(mode).toBe('dark')
     expect(localStorage.getItem('theme')).toBe('vermelho')
     expect(localStorage.getItem('mode')).toBe('dark')
-    expect(root.getAttribute('data-theme')).toBe('vermelho')
-    expect(root.getAttribute('data-mode')).toBe('dark')
+    expect(body.getAttribute('data-theme')).toBe('vermelho')
+    expect(body.getAttribute('data-mode')).toBe('dark')
   })
 
   it('idempotência de applyTheme', () => {
@@ -40,9 +40,9 @@ describe('utils de tema', () => {
         applyTheme('ciano', 'dark')
       }
     }).not.toThrow()
-    const root = document.documentElement
-    expect(root.getAttribute('data-theme')).toBe('ciano')
-    expect(root.getAttribute('data-mode')).toBe('dark')
+    const body = document.body
+    expect(body.getAttribute('data-theme')).toBe('ciano')
+    expect(body.getAttribute('data-mode')).toBe('dark')
     expect(localStorage.getItem('theme')).toBe('ciano')
     expect(localStorage.getItem('mode')).toBe('dark')
   })

--- a/frontend/src/theme/utils.ts
+++ b/frontend/src/theme/utils.ts
@@ -18,8 +18,8 @@ export function saveMode(mode: ModeKey) {
 
 export function applyTheme(theme: ThemeName, mode: ModeKey = 'light') {
   if (typeof document !== 'undefined') {
-    document.documentElement.setAttribute('data-theme', theme)
-    document.documentElement.setAttribute('data-mode', mode)
+    document.body.setAttribute('data-theme', theme)
+    document.body.setAttribute('data-mode', mode)
   }
   if (typeof window !== 'undefined') {
     try {
@@ -31,21 +31,21 @@ export function applyTheme(theme: ThemeName, mode: ModeKey = 'light') {
 }
 
 export function loadThemeFromStorage(): { theme: ThemeName; mode: ModeKey } {
-  let theme: ThemeName = 'default'
+  let theme: ThemeName = 'roxo'
   let mode: ModeKey = 'light'
   if (typeof window !== 'undefined') {
     try {
       const storedTheme = localStorage.getItem('theme') as ThemeName | null
       const storedMode = localStorage.getItem('mode') as ModeKey | null
-      theme = storedTheme || 'default'
+      theme = storedTheme || 'roxo'
       mode = storedMode || 'light'
       if (!storedTheme) localStorage.setItem('theme', theme)
       if (!storedMode) localStorage.setItem('mode', mode)
     } catch {}
   }
   if (typeof document !== 'undefined') {
-    document.documentElement.setAttribute('data-theme', theme)
-    document.documentElement.setAttribute('data-mode', mode)
+    document.body.setAttribute('data-theme', theme)
+    document.body.setAttribute('data-mode', mode)
   }
   console.info('[theme] load:', theme, mode)
   return { theme, mode }

--- a/frontend/src/theme/visual.test.ts
+++ b/frontend/src/theme/visual.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { applyTheme } from './utils'
+import '../styles/theme.css'
+
+// simple visual check that tokens propagate to elements
+
+describe('visual tokens', () => {
+  it('applies theme colors to components', () => {
+    document.body.innerHTML = `<nav class="navbar"></nav><button class="btn btn-primary"></button><div class="card"></div>`
+    applyTheme('azul', 'light')
+    const primary = getComputedStyle(document.body).getPropertyValue('--color-primary').trim()
+    const btn = getComputedStyle(document.querySelector('.btn-primary') as Element).backgroundColor
+    const card = getComputedStyle(document.querySelector('.card') as Element).backgroundColor
+    expect(primary).not.toBe('')
+    expect(btn).not.toBe('')
+    expect(card).not.toBe('')
+  })
+})


### PR DESCRIPTION
## Summary
- centralize theme tokens and add primary/success utilities
- persist theme selection via new /me/preferences/theme endpoints
- initial tests for theme utilities and visual tokens

## Testing
- `npx --yes stylelint "frontend/src/**/*.css"` *(fails: No configuration provided)*
- `npx --yes eslint "frontend/src/**/*.{ts,tsx}" --max-warnings=0` *(fails: missing eslint.config.js)*
- `npx --yes vitest run frontend/src/theme/utils.test.ts frontend/src/theme/visual.test.ts --environment jsdom` *(fails: Cannot find package 'jsdom')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8e15a340483229d9de1e6c278e52c