### PR TITLE
refactor: use theme tokens for menu and alerts

### DIFF
--- a/frontend/src/styles/CadastrarUsuario.css
+++ b/frontend/src/styles/CadastrarUsuario.css
@@ -39,8 +39,8 @@
 /* Estados e mensagens */
 .carregando { color: var(--pp-muted); }
 .alerta { padding: 10px 12px; border-radius: 10px; font-size: 14px; }
-.alerta.erro { background: var(--primary-color); color: var(--text-color); border: 1px solid #fecaca; }
-.alerta.sucesso { background: var(--primary-color); color: var(--text-color); border: 1px solid #bbf7d0; }
+  .alerta.erro { background: var(--primary-color); color: var(--text-color); border: 1px solid var(--color-error-border); }
+  .alerta.sucesso { background: var(--primary-color); color: var(--text-color); border: 1px solid var(--color-success-border); }
 
 /* Responsivo */
 @media (max-width: 700px) {

--- a/frontend/src/styles/HamburgerMenu.css
+++ b/frontend/src/styles/HamburgerMenu.css
@@ -59,12 +59,12 @@
 }
 
 /* Overlay escurecido do fundo quando o drawer abre */
-.hamburger-overlay {
-  position: fixed; /* Mantém overlay fixo na tela */
-  inset: 0; /* Ocupa toda a área da janela */
-  background: rgba(0, 0, 0, 0.45); /* Define fundo semitransparente */
-  z-index: 1000; /* Fica abaixo do botão e acima do conteúdo */
-}
+  .hamburger-overlay {
+    position: fixed; /* Mantém overlay fixo na tela */
+    inset: 0; /* Ocupa toda a área da janela */
+    background: var(--overlay-bg); /* Define fundo semitransparente */
+    z-index: 1000; /* Fica abaixo do botão e acima do conteúdo */
+  }
 
 /* Drawer lateral (menu) em modo fechado */
 .hamburger-drawer {
@@ -74,8 +74,8 @@
   left: 0; /* Alinha à esquerda da tela */
   width: 84%; /* Define largura do drawer em mobile */
   max-width: 320px; /* Define largura máxima para consistência */
-  background: var(--primary-color); /* Define fundo branco para conteúdo */
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25); /* Adiciona sombra para elevação */
+    background: var(--primary-color); /* Define fundo branco para conteúdo */
+    box-shadow: var(--drawer-shadow); /* Adiciona sombra para elevação */
   transform: translateX(-110%); /* Esconde fora da tela quando fechado */
   transition: transform 240ms ease; /* Anima abertura/fechamento suave */
   z-index: 1001; /* Fica acima do overlay e abaixo do botão */

--- a/frontend/src/styles/theme.css
+++ b/frontend/src/styles/theme.css
@@ -13,6 +13,10 @@
   --color-success: #16a34a;
   --color-error: #dc2626;
   --color-white: #ffffff;
+  --color-success-border: #bbf7d0;
+  --color-error-border: #fecaca;
+  --overlay-bg: rgba(0,0,0,0.45);
+  --drawer-shadow: 0 10px 30px rgba(0,0,0,0.25);
 
   /* aliases for legacy variables */
   --primary-color: var(--primary);


### PR DESCRIPTION
## Summary
- add overlay and border tokens to theme.css
- use shared color tokens in hamburger menu and alerts

## Testing
- `npm test` *(fails: expected '' not to be '')*


------
https://chatgpt.com/codex/tasks/task_e_68a8ebe5653c832296729aedbca6d1fb