### PR TITLE
Enforce SECRET_KEY environment configuration

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -18,7 +18,9 @@ from datetime import datetime, timedelta     # Importa utilitários de data e te
 from jose import jwt                         # Importa biblioteca JOSE para geração de JWT
 
 # Lê a chave do JWT priorizando SECRET_KEY (compatibilidade com nomes antigos)
-SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET", "change-me-in-prod")  # Define chave secreta do JWT
+SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET")  # Define chave secreta do JWT
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable is not set")
 ALGORITHM = os.getenv("JWT_ALG", "HS256")                 # Define algoritmo de assinatura
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.getenv("JWT_EXPIRE_MINUTES", "60"))  # Define expiração padrão
 

--- a/backend/security.py
+++ b/backend/security.py
@@ -8,8 +8,10 @@ from jose import jwt, JWTError
 logger = logging.getLogger(__name__)
 
 # Lê chave e algoritmo do JWT a partir das variáveis de ambiente
-# Mantém compatibilidade com nomes antigos, mas prioriza SECRET_KEY
-SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET", "change-me-in-prod")
+# Mantém compatibilidade com nomes antigos, mas levanta erro se ausente
+SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable is not set")
 ALGORITHM = os.getenv("JWT_ALG", "HS256")
 
 

--- a/backend/tests/test_auth_endpoints.py
+++ b/backend/tests/test_auth_endpoints.py
@@ -13,6 +13,7 @@ def setup_app_env():
     os.environ.setdefault("GOOGLE_CLIENT_SECRET", "secret")
     os.environ.setdefault("GOOGLE_REDIRECT_URI", "https://api.example/google-callback")
     os.environ.setdefault("DATABASE_URL", "sqlite:///test.db")
+    os.environ.setdefault("SECRET_KEY", "test-secret")
 
 
 setup_app_env()

--- a/backend/tests/test_missing_secret_key.py
+++ b/backend/tests/test_missing_secret_key.py
@@ -1,0 +1,30 @@
+import importlib
+import sys
+import pytest
+
+
+def _import_fresh(module_name: str):
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    return importlib.import_module(module_name)
+
+
+def test_security_requires_secret_key(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        _import_fresh("backend.security")
+
+
+def test_token_requires_secret_key(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        _import_fresh("backend.utils.token")
+
+
+def test_main_requires_secret_key(monkeypatch):
+    monkeypatch.delenv("SECRET_KEY", raising=False)
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    with pytest.raises(RuntimeError):
+        _import_fresh("backend.main")

--- a/backend/utils/token.py
+++ b/backend/utils/token.py
@@ -4,7 +4,9 @@ from jose import jwt
 import os
 
 # Define a chave secreta e algoritmo
-SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET", "sua-chave-secreta-super-segura")
+SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET")
+if not SECRET_KEY:
+    raise RuntimeError("SECRET_KEY environment variable is not set")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
 

--- a/docs/SECRET_KEY.md
+++ b/docs/SECRET_KEY.md
@@ -1,0 +1,17 @@
+# Configuração da SECRET_KEY
+
+A aplicação utiliza tokens JWT para autenticação e **exige** que a variável de ambiente `SECRET_KEY` esteja definida.
+Sem essa variável o backend não inicia.
+
+## Desenvolvimento
+
+Crie um arquivo `.env` na pasta `backend/` ou defina a variável no ambiente antes de executar o servidor:
+
+```bash
+export SECRET_KEY="sua-chave-segura"
+uvicorn backend.main:app
+```
+
+## Produção
+
+Defina `SECRET_KEY` no ambiente de execução da aplicação utilizando o mecanismo de secrets do seu provedor ou um arquivo `.env` seguro. Nunca versione este valor.


### PR DESCRIPTION
## Summary
- Require SECRET_KEY environment variable in security, token utility, and main module
- Document how to configure SECRET_KEY for development and production
- Add tests ensuring modules fail to load without SECRET_KEY

## Testing
- `pytest -q` *(fails: import file mismatch)*
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ec76d0d8832288d0facece29b7f9