### PR TITLE
Remover menu de Ano Letivo em configuração

### DIFF
--- a/frontend/src/pages/Home/Home.tsx
+++ b/frontend/src/pages/Home/Home.tsx
@@ -16,7 +16,6 @@ const CadastrarUsuario = React.lazy(() => import('../Usuarios/CadastrarUsuario')
 const ConsultarUsuario  = React.lazy(() => import('../Usuarios/ConsultarUsuario'))
 const Logs = React.lazy(() => import('../Logs/Logs'))
 const ConfigurarTema = React.lazy(() => import('../Configuracoes/ConfigurarTema'))
-const ConfigAnoLetivo = React.lazy(() => import('../Configuracoes/AnoLetivo/AnoLetivoPage'))
 const AcessosConsultar = React.lazy(() => import('../Configuracoes/Acessos/Consultar'))
 const AcessoUsuario = React.lazy(() => import('../Configuracoes/Acessos/Usuario'))
 const AcessoGrupo = React.lazy(() => import('../Configuracoes/Acessos/Grupo'))
@@ -288,10 +287,6 @@ const Home: React.FC = () => {
       )
     }
 
-    if (path.includes('/configuracao/ano-letivo')) {
-      return renderWithAuth(can('/configuracao/ano-letivo', 'view'), <ConfigAnoLetivo />)
-    }
-
     if (path.includes('/configuracao/logs')) {
       if (!isMaster) {
         return (
@@ -439,12 +434,6 @@ const Home: React.FC = () => {
                       Configurar Tema
                     </button>
                   )}
-                {can('/configuracao/ano-letivo') && (
-                  <button className="btn btn-md submenu-link" onClick={() => navigate('/configuracao/ano-letivo')}>
-                    Ano Letivo
-                  </button>
-                )}
-
                   {(can('/configuracao/acessos/consultar') ||
                     can('/configuracao/acessos/usuario') ||
                     can('/configuracao/acessos/grupo')) && (

--- a/frontend/src/routes/routesConfig.ts
+++ b/frontend/src/routes/routesConfig.ts
@@ -50,12 +50,6 @@ export const routesConfig: AppRoute[] = [
     meta: { area: 'config', menu: true, requiresAuth: true },
   },
   {
-    path: '/configuracao/ano-letivo',
-    name: 'Ano Letivo',
-    component: lazy(() => import('@/pages/Configuracoes/AnoLetivo/AnoLetivoPage')),
-    meta: { area: 'config', menu: true, requiresAuth: true },
-  },
-  {
     path: '/configuracao/logs',
     name: 'Logs',
     component: lazy(() => import('@/pages/Logs/Logs')),


### PR DESCRIPTION
## Resumo
- remove entrada de menu e rota de "Ano Letivo" na área de configuração
- ajusta lógica da Home para não exibir nem renderizar página de configuração de ano letivo

## Testes
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab90d963208322b1f8e859ba5a00e8