### PR TITLE
feat: add theme preference endpoints

### DIFF
--- a/backend/tests/test_theme_preferences.py
+++ b/backend/tests/test_theme_preferences.py
@@ -53,8 +53,7 @@ def _create_client():
 
     return TestClient(app), TestingSessionLocal
 
-def test_update_theme_preference():
-    client, SessionLocal = _create_client()
+def _seed_user(SessionLocal):
     with SessionLocal() as db:
         db.add(
             Usuarios(
@@ -70,10 +69,36 @@ def test_update_theme_preference():
         )
         db.commit()
 
+
+def test_get_theme_preference_default():
+    client, SessionLocal = _create_client()
+    _seed_user(SessionLocal)
+
+    resp = client.get("/me/preferences/theme")
+    assert resp.status_code == 200
+    assert resp.json() == {"themeName": "roxo", "themeMode": "light"}
+
+
+def test_update_and_get_theme_preference():
+    client, SessionLocal = _create_client()
+    _seed_user(SessionLocal)
+
     resp = client.put("/me/preferences/theme", json={"themeName": "azul", "themeMode": "dark"})
     assert resp.status_code == 204
+
+    resp = client.get("/me/preferences/theme")
+    assert resp.status_code == 200
+    assert resp.json() == {"themeName": "azul", "themeMode": "dark"}
 
     with SessionLocal() as db:
         user = db.query(Usuarios).filter_by(id_usuario=1).first()
         assert user.preferences["themeName"] == "azul"
         assert user.preferences["themeMode"] == "dark"
+
+
+def test_update_theme_preference_invalid():
+    client, SessionLocal = _create_client()
+    _seed_user(SessionLocal)
+
+    resp = client.put("/me/preferences/theme", json={"themeName": "invalido", "themeMode": "dark"})
+    assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- allow users to save interface theme (color/mode)
- expose new `/me/preferences/theme` read/write endpoints
- validate theme payload and return defaults when missing

## Testing
- `pytest tests/test_theme_preferences.py -q`
- `curl -H "Authorization: Bearer TEST" http://localhost:8000/me/preferences/theme`
- `curl -X PUT -H "Authorization: Bearer TEST" -H "Content-Type: application/json" -d '{"themeName":"verde","themeMode":"dark"}' http://localhost:8000/me/preferences/theme -v`
- `curl -H "Authorization: Bearer TEST" http://localhost:8000/me/preferences/theme`


------
https://chatgpt.com/codex/tasks/task_e_68ac9f7845508322b99ce0636df52aa7