### PR TITLE
Add theme preferences API and frontend sync

### DIFF
--- a/README/API.md
+++ b/README/API.md
@@ -1,32 +1,31 @@
-# Contrato de Preferências de Tema
+# Preferências de Tema
 
-Este documento descreve um contrato preliminar para a sincronização de preferências de tema dos usuários.
+Esta API permite sincronizar o tema visual do usuário entre dispositivos.
 
 ## Endpoints
 
-### `GET /users/{id}/preferences/theme`
-Retorna a preferência de tema do usuário.
+### `GET /me/preferences/theme`
+Retorna a preferência de tema do usuário autenticado.
 
 #### Resposta
 ```json
-{ "theme": "dark" }
+{ "themeName": "roxo", "themeMode": "light" }
 ```
 
-### `PUT /users/{id}/preferences/theme`
-Atualiza a preferência de tema do usuário.
+### `PUT /me/preferences/theme`
+Atualiza a preferência de tema do usuário autenticado.
 
 #### Corpo da requisição
 ```json
-{ "theme": "light" }
+{ "themeName": "azul", "themeMode": "dark" }
 ```
 
 #### Resposta
-Código 204 sem corpo.
+`204 No Content`
 
-## Valores aceitos
-- `light`: tema claro
-- `dark`: tema escuro
-- `system`: acompanha o tema do sistema
+#### Erros
+- `400 Bad Request` – valores de tema inválidos
 
-Este contrato é apenas uma proposta e poderá ser alterado conforme a implementação evoluir.
-
+## Valores permitidos
+- **themeName**: `roxo`, `azul`, `verde`, `laranja`, `cinza`, `teal`, `ciano`, `rosa`, `violeta`, `ambar`
+- **themeMode**: `light`, `dark`

--- a/backend/tests/test_theme_preferences.py
+++ b/backend/tests/test_theme_preferences.py
@@ -77,3 +77,47 @@ def test_update_theme_preference():
         user = db.query(Usuarios).filter_by(id_usuario=1).first()
         assert user.preferences["themeName"] == "azul"
         assert user.preferences["themeMode"] == "dark"
+
+
+def test_get_theme_preference():
+    client, SessionLocal = _create_client()
+    with SessionLocal() as db:
+        db.add(
+            Usuarios(
+                id_usuario=1,
+                nome="User",
+                email="user@example.com",
+                senha_hash="x",
+                tipo_perfil="Admin",
+                numero_celular="1",
+                ddd="11",
+                ddi="55",
+                preferences={"themeName": "verde", "themeMode": "light"},
+            )
+        )
+        db.commit()
+
+    resp = client.get("/me/preferences/theme")
+    assert resp.status_code == 200
+    assert resp.json() == {"themeName": "verde", "themeMode": "light"}
+
+
+def test_update_theme_preference_invalid():
+    client, SessionLocal = _create_client()
+    with SessionLocal() as db:
+        db.add(
+            Usuarios(
+                id_usuario=1,
+                nome="User",
+                email="user@example.com",
+                senha_hash="x",
+                tipo_perfil="Admin",
+                numero_celular="1",
+                ddd="11",
+                ddi="55",
+            )
+        )
+        db.commit()
+
+    resp = client.put("/me/preferences/theme", json={"themeName": "invalido", "themeMode": "dark"})
+    assert resp.status_code == 400

--- a/frontend/src/components/Login.tsx
+++ b/frontend/src/components/Login.tsx
@@ -8,6 +8,7 @@ import useBaseNavigate from '@/hooks/useBaseNavigate'
 
 // Base da API e utilidades de autenticação
 import { API_BASE, getAuthToken, setAuthToken, authFetch } from "@/services/api";
+import { syncThemePreference } from '@/services/themePreferences'
 
 // Importa o arquivo CSS da tela de login
 import "../styles/Login.css";
@@ -108,6 +109,7 @@ const Login: React.FC = () => {
               window.dispatchEvent(new Event('permissions:updated'));
             }
           } catch {}
+          await syncThemePreference();
         }
       } catch {}
       navigate('/home');

--- a/frontend/src/services/themePreferences.test.ts
+++ b/frontend/src/services/themePreferences.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { syncThemePreference } from './themePreferences'
+import { getCurrentTheme, getCurrentMode } from '../utils/theme'
+
+vi.stubGlobal('fetch', () =>
+  Promise.resolve(
+    new Response(
+      JSON.stringify({ themeName: 'azul', themeMode: 'dark' }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    )
+  )
+)
+
+describe('theme preference sync', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.removeAttribute('data-theme')
+    document.documentElement.removeAttribute('data-mode')
+  })
+
+  it('applies preferences from backend', async () => {
+    await syncThemePreference()
+    expect(getCurrentTheme()).toBe('azul')
+    expect(getCurrentMode()).toBe('dark')
+    expect(document.documentElement.getAttribute('data-theme')).toBe('azul')
+    expect(document.documentElement.getAttribute('data-mode')).toBe('dark')
+    expect(localStorage.getItem('pp.theme')).toBe('azul')
+  })
+})

--- a/frontend/src/services/themePreferences.ts
+++ b/frontend/src/services/themePreferences.ts
@@ -1,0 +1,21 @@
+import { apiFetch } from './api'
+import { setCurrentTheme, setCurrentMode, ThemeSlug, Mode } from '../utils/theme'
+
+export interface ThemePreference {
+  themeName: ThemeSlug
+  themeMode: Mode
+}
+
+export async function getThemePreference(): Promise<ThemePreference> {
+  return await apiFetch('/me/preferences/theme', { method: 'GET' })
+}
+
+export async function syncThemePreference(): Promise<void> {
+  try {
+    const prefs = await getThemePreference()
+    if (prefs?.themeName) setCurrentTheme(prefs.themeName)
+    if (prefs?.themeMode) setCurrentMode(prefs.themeMode)
+  } catch {
+    // ignore errors to avoid blocking login
+  }
+}


### PR DESCRIPTION
## Summary
- Document and implement GET/PUT `/me/preferences/theme` endpoints
- Sync theme preference on login and expose theme service
- Cover theme preference API with tests and docs

## Testing
- `pytest tests/test_theme_preferences.py -q`
- `npx vitest run src/services/themePreferences.test.ts --silent`
- `npm run lint --silent` *(fails: Invalid option '--ext')*


------
https://chatgpt.com/codex/tasks/task_e_68ac9f823ee8832289c2e1b24815f085