### PR TITLE
fix: require configured JWT secret key

### DIFF
--- a/backend/routers/usuarios_delete.py
+++ b/backend/routers/usuarios_delete.py
@@ -7,13 +7,9 @@ from sqlalchemy.orm import Session
 from backend.database import get_db
 from backend.models.usuarios import Usuarios
 from backend.utils.audit import registrar_log, log_403
-import os
 import logging
 from jose import jwt, JWTError
-
-# Utiliza SECRET_KEY como padrão para assinatura do JWT
-SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET_KEY", "change-me-in-prod")
-ALGORITHM = os.getenv("JWT_ALGORITHM", "HS256")
+from backend.security import SECRET_KEY, ALGORITHM
 MAX_JWT_BYTES = 256 * 1024
 
 logger = logging.getLogger(__name__)

--- a/backend/routes/usuarios.py
+++ b/backend/routes/usuarios.py
@@ -11,10 +11,7 @@ from backend.database import get_db
 from backend.models.usuarios import Usuarios as UsuariosModel
 from backend.utils.audit import registrar_log, log_403
 from backend.utils.pdf import generate_pdf
-
-# Lê a chave do JWT priorizando SECRET_KEY para compatibilidade
-SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET_KEY", "change-me-in-prod")
-ALGORITHM  = "HS256"
+from backend.security import SECRET_KEY, ALGORITHM
 ALLOWED_PERFIS = {"master", "diretor", "secretaria"}
 MAX_JWT_BYTES = 256 * 1024
 

--- a/backend/services/permissions.py
+++ b/backend/services/permissions.py
@@ -16,10 +16,10 @@ from backend.models import (
     GrupoPermissao,
     UsuarioPermissaoTemp,
 )
-import os
 from jose import jwt, JWTError
 from pydantic import BaseModel, EmailStr
 import logging
+from backend.security import SECRET_KEY, ALGORITHM
 
 logger = logging.getLogger(__name__)
 
@@ -37,8 +37,6 @@ CANON_TO_ENUM = {
 }
 
 
-SECRET_KEY = os.getenv("SECRET_KEY") or os.getenv("JWT_SECRET_KEY", "change-me-in-prod")
-ALGORITHM = "HS256"
 MAX_JWT_BYTES = 256 * 1024
 
 


### PR DESCRIPTION
## Summary
- centralize JWT SECRET_KEY retrieval via `backend.security` to avoid insecure defaults

## Testing
- `pytest` *(fails: sqlalchemy.exc.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e95cb1f483229a129e5ff31728cf