### PR TITLE
feat: configure CORS with frontend origin env

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -169,10 +169,12 @@ def favicon():
 # ======================================================
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[os.getenv("FRONTEND_ORIGIN")],
-    allow_methods=["*"],
-    allow_headers=["Authorization", "Content-Type"],
-    allow_credentials=False,
+    allow_origins=[
+        os.getenv("FRONTEND_ORIGIN", "https://portaldoprofessor.web.app/")
+    ],
+    allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["*"],
+    allow_credentials=False,  # true só se usar cookies/sessão
 )
 
 # ======================================================


### PR DESCRIPTION
## Summary
- configure CORS to use FRONTEND_ORIGIN env var with fallback default
- limit allowed methods and allow all headers

## Testing
- `cd backend && pytest tests/test_auth_endpoints.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca4add4bc8322ab00ee191f2012be